### PR TITLE
matching event payload type def to v2

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ interface IEventAccountsPayload {
 interface IElementClientOnEventPayload {
   op: TEventTypes;
   element_type: string;
+  entity_id?: string;
   accounts?: IEventAccountsPayload[];
 }
 


### PR DESCRIPTION
in v2 we surface `entity_id` in certain event payloads. updating the type definition to match this.